### PR TITLE
Support `autobins` and target renaming `[lib]` and `[[bin]]`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cargo-subcommand"
 version = "0.11.0"
 authors = ["David Craven <david@craven.ch>", "Marijn Suijten <marijn@traverseresearch.nl>"]
-edition = "2018"
+edition = "2021"
 description = "Library for creating cargo subcommands."
 repository = "https://github.com/dvc94ch/cargo-subcommand"
 license = "ISC"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
-# cargo-subcommand library for building subcommands
-Is used by `cargo-apk` and `cargo-flutter`.
+# `cargo-subcommand` library for building subcommands
+
+Is used by [`cargo-apk`](https://crates.io/crates/cargo-apk) and `cargo-flutter`.
 
 # License
+
 Copyright 2020 David Craven <david@craven.ch>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/src/args.rs
+++ b/src/args.rs
@@ -130,4 +130,13 @@ impl Args {
             Profile::Dev
         }
     }
+
+    /// Returns [`true`] when one or more target selection options are active.
+    /// This is generally used to deduce whether to default to binary and
+    /// library targets, in accordance with [`cargo build`].
+    ///
+    /// [`cargo build`]: https://doc.rust-lang.org/cargo/commands/cargo-build.html#target-selection
+    pub fn specific_target_selected(&self) -> bool {
+        self.lib || self.bins || self.examples || !self.bin.is_empty() || !self.example.is_empty()
+    }
 }

--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -1,50 +1,54 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub enum Artifact {
-    Root(String),
-    Example(String),
+use crate::manifest::CrateType;
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum ArtifactType {
+    Lib,
+    Bin,
+    Example,
+    // Bench,
+    // Test,
 }
 
-impl AsRef<Path> for Artifact {
-    fn as_ref(&self) -> &Path {
-        Path::new(match self {
-            Self::Root(_) => "",
-            Self::Example(_) => "examples",
-        })
-    }
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct Artifact {
+    pub name: String,
+    pub path: PathBuf,
+    pub r#type: ArtifactType,
 }
 
 impl Artifact {
-    pub fn name(&self) -> &str {
-        match self {
-            Self::Root(name) => name,
-            Self::Example(name) => name,
-        }
+    pub fn build_dir(&self) -> &'static Path {
+        Path::new(match self.r#type {
+            ArtifactType::Lib | ArtifactType::Bin => "",
+            ArtifactType::Example => "examples",
+        })
     }
 
+    // TODO: CrateType should be read from the manifest' crate-type array,
+    // and validated that the requested format is in that array
     pub fn file_name(&self, ty: CrateType, target: &str) -> String {
-        match ty {
-            CrateType::Bin => {
+        match (self.r#type, ty) {
+            (ArtifactType::Bin | ArtifactType::Example, CrateType::Bin) => {
                 if target.contains("windows") {
-                    format!("{}.exe", self.name())
+                    format!("{}.exe", self.name)
                 } else if target.contains("wasm") {
-                    format!("{}.wasm", self.name())
+                    format!("{}.wasm", self.name)
                 } else {
-                    self.name().to_string()
+                    self.name.to_string()
                 }
             }
-            CrateType::Lib => format!("lib{}.rlib", self.name().replace('-', "_")),
-            CrateType::Staticlib => format!("lib{}.a", self.name().replace('-', "_")),
-            CrateType::Cdylib => format!("lib{}.so", self.name().replace('-', "_")),
+            (ArtifactType::Lib | ArtifactType::Example, CrateType::Lib) => {
+                format!("lib{}.rlib", self.name.replace('-', "_"))
+            }
+            (ArtifactType::Lib | ArtifactType::Example, CrateType::Staticlib) => {
+                format!("lib{}.a", self.name.replace('-', "_"))
+            }
+            (ArtifactType::Lib | ArtifactType::Example, CrateType::Cdylib) => {
+                format!("lib{}.so", self.name.replace('-', "_"))
+            }
+            (a, c) => panic!("{a:?} is not compatible with {c:?}"),
         }
     }
-}
-
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub enum CrateType {
-    Bin,
-    Lib,
-    Staticlib,
-    Cdylib,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,6 +22,9 @@ pub enum Error {
     },
     Io(PathBuf, IoError),
     Toml(PathBuf, TomlError),
+    BinNotFound(String),
+    DuplicateBin(String),
+    DuplicateExample(String),
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -74,6 +77,9 @@ Alternatively, to keep it out of the workspace, add an empty `[workspace]` table
             },
             Self::Io(path, error) => return write!(f, "{}: {}", path.display(), error),
             Self::Toml(file, error) => return write!(f, "{}: {}", file.display(), error),
+            Self::BinNotFound(name) => return write!(f, "Can't find `{name}` bin at `src/bin/{name}.rs` or `src/bin/{name}/main.rs`. Please specify bin.path if you want to use a non-default path.", name = name),
+            Self::DuplicateBin(name) => return write!(f, "found duplicate binary name {name}, but all binary targets must have a unique name"),
+            Self::DuplicateExample(name) => return write!(f, "found duplicate example name {name}, but all example targets must have a unique name"),
         })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,8 +8,9 @@ mod subcommand;
 mod utils;
 
 pub use args::Args;
-pub use artifact::{Artifact, CrateType};
+pub use artifact::{Artifact, ArtifactType};
 pub use config::{EnvError, EnvOption, LocalizedConfig};
 pub use error::Error;
+pub use manifest::CrateType;
 pub use profile::Profile;
 pub use subcommand::Subcommand;

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -11,6 +11,11 @@ use crate::utils;
 pub struct Manifest {
     pub workspace: Option<Workspace>,
     pub package: Option<Package>,
+    pub lib: Option<Lib>,
+    #[serde(default, rename = "bin")]
+    pub bins: Vec<Bin>,
+    #[serde(default, rename = "example")]
+    pub examples: Vec<Example>,
 }
 
 impl Manifest {
@@ -90,7 +95,50 @@ pub struct Workspace {
     pub members: Vec<String>,
 }
 
+const fn default_true() -> bool {
+    true
+}
+
 #[derive(Clone, Debug, Deserialize)]
 pub struct Package {
     pub name: String,
+
+    // https://doc.rust-lang.org/cargo/reference/cargo-targets.html#target-auto-discovery
+    #[serde(default = "default_true")]
+    pub autobins: bool,
+    #[serde(default = "default_true")]
+    pub autoexamples: bool,
+    // #[serde(default = "default_true")]
+    // pub autotests: bool,
+    // #[serde(default = "default_true")]
+    // pub autobenches: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Deserialize)]
+pub enum CrateType {
+    Bin,
+    Lib,
+    Staticlib,
+    Cdylib,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct Lib {
+    pub name: Option<String>,
+    pub path: Option<PathBuf>,
+    // pub crate_type: Vec<CrateType>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct Bin {
+    pub name: String,
+    pub path: Option<PathBuf>,
+    // pub crate_type: Vec<CrateType>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct Example {
+    pub name: String,
+    pub path: Option<PathBuf>,
+    // pub crate_type: Vec<CrateType>,
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,15 +4,14 @@ use crate::manifest::Manifest;
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 
-pub fn list_rust_files(dir: &Path) -> Result<Vec<String>> {
-    let mut files = Vec::new();
+pub fn list_rust_files(dir: &Path) -> Result<Vec<PathBuf>> {
+    let mut files = vec![];
     if dir.exists() && dir.is_dir() {
         let entries = std::fs::read_dir(dir).map_err(|e| Error::Io(dir.to_owned(), e))?;
         for entry in entries {
             let path = entry.map_err(|e| Error::Io(dir.to_owned(), e))?.path();
             if path.is_file() && path.extension() == Some(OsStr::new("rs")) {
-                let name = path.file_stem().unwrap().to_str().unwrap();
-                files.push(name.to_string());
+                files.push(path);
             }
         }
     }


### PR DESCRIPTION
Fixes https://github.com/rust-mobile/cargo-apk/issues/7

@dvc94ch this WIP PR pulls the lib rename changes out of #15 and expands it with similar changes for `[[bin]]` and supporting `autobins=false`.  We'll have to rework what `Artifact`s to return to the user given that by default the library _and all binary targets_ are built: https://doc.rust-lang.org/cargo/commands/cargo-build.html#target-selection.  This is different for `cargo run` which only picks one binary target (I think from the shared pool of `src/main.rs`, `src/bin/*`, _and_ any other file specified through `[[bin]]`) and otherwise errors out.

At the same time I'm thinking about renaming `Root` to `Lib` and `Bin` or otherwise passing such information, so that a caller like `cargo-apk` knows what it builds (and error accordingly, since `cargo-apk` always tries to package `lib<artifact>.so` when it is in fact a binary... resulting in the usual cryptic errors).
