### PR TITLE
Add separate `ExampleNotFound` `Error` instead of mis-using `BinNotFound`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -23,6 +23,7 @@ pub enum Error {
     Io(PathBuf, IoError),
     Toml(PathBuf, TomlError),
     BinNotFound(String),
+    ExampleNotFound(String),
     DuplicateBin(String),
     DuplicateExample(String),
 }
@@ -78,6 +79,7 @@ Alternatively, to keep it out of the workspace, add an empty `[workspace]` table
             Self::Io(path, error) => return write!(f, "{}: {}", path.display(), error),
             Self::Toml(file, error) => return write!(f, "{}: {}", file.display(), error),
             Self::BinNotFound(name) => return write!(f, "Can't find `{name}` bin at `src/bin/{name}.rs` or `src/bin/{name}/main.rs`. Please specify bin.path if you want to use a non-default path.", name = name),
+            Self::ExampleNotFound(name) => return write!(f, "Can't find `{name}` example at `examples/{name}.rs` or `examples/{name}/main.rs`. Please specify examples.path if you want to use a non-default path.", name = name),
             Self::DuplicateBin(name) => return write!(f, "found duplicate binary name {name}, but all binary targets must have a unique name"),
             Self::DuplicateExample(name) => return write!(f, "found duplicate example name {name}, but all example targets must have a unique name"),
         })

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -158,7 +158,7 @@ impl Subcommand {
                 .path
                 .clone()
                 .or_else(|| find_main_file(&root_dir.join("examples"), &example.name))
-                .ok_or_else(|| Error::BinNotFound(example.name.clone()))?;
+                .ok_or_else(|| Error::ExampleNotFound(example.name.clone()))?;
 
             let prev = example_artifacts.insert(
                 example.name.clone(),


### PR DESCRIPTION
The reported error and suggestion is completely incorrect when trying to run an example that doesn't exist.
